### PR TITLE
Minor fixes in German translation

### DIFF
--- a/de.haml
+++ b/de.haml
@@ -19,16 +19,16 @@
         .span12
             %ol
                 %li Bitte bewahre eine angenehme Atmosphäre. Sei respektvoll zu anderen und nutze deinen Verstand. Exzessives Schimpfen, Unfreundlichkeit und Belästigung anderer wird nicht toleriert.
-                %li Versuche korrekte Grammatik und Rechtschreibung einzuhalten (English und andere Sprachen).
+                %li Versuche korrekte Grammatik und Rechtschreibung einzuhalten (Englisch und andere Sprachen).
                 %li Kein Spam im Chat.
                 %li Verlinke keines der folgenden Dinge:
                 %ul
-                    %li Pornographische Inhalte, "Schock" Seiten, Viren oder Phishing-Seiten oder Nationalsozialistische Inhalte.
+                    %li Pornografische Inhalte, "Schock" Seiten, Viren oder Phishing-Seiten oder nationalsozialistische Inhalte.
                     %li Werbung für andere Server
-                %li Weder Regeln brechen noch das Unterstützen des Regelbruchs ist toleriert.
+                %li Regelverstöße, sowie die Unterstützung selbiger wird nicht toleriert.
                 %li Behaupte nicht du wärst ein Moderator auf diesem Server, wenn du keiner bist.
-                %li Sende Bugs oder dergleichen and support@oc.tc oder erstelle einen Thread in den Foren (http://oc.tc/forums); Das Ausnutzen von Bugs wird bestraft, ausser du wurdest von einem Moderator angewiesen, den Bug zu demonstrieren
-                %li Befolge alle Anweisungen eines Overcast Network Moderator. Wenn du glaubst, ein Moderator hat dich falsch angewiesen oder misleitet, sende eine Email an support@oc.tc
+                %li Sende Bugs oder dergleichen and support@oc.tc oder erstelle einen Thread in den Foren (http://oc.tc/forums); Das Ausnutzen von Bugs wird bestraft, ausser du wurdest von einem Moderator angewiesen, den Bug zu demonstrieren.
+                %li Befolge alle Anweisungen eines Overcast Network Moderator. Wenn du glaubst, ein Moderator hat dich falsch angewiesen oder in die Irre geführt, sende eine Email an support@oc.tc.
                 %span.label.label-warning Beachte
                 %small Berate dich mit einen Moderator bevor du einen möglicherweise als Werbung geltenden Link postest.
 
@@ -37,31 +37,31 @@
     .row
         .span12
             %ol
-                %li Starte keine "Flame Wars". Dies beinhaltet das Erstellen von Posts die eine Person beleidigen oder sie dazu anstiften eine "Flame War" zu starten. Hasstiraden oder dergleichen sind ebenfalls nicht erlaubt.
-                %li Alle Posts sollten zum Thema beitragen. Unnötige Posts (Off-Topic) werden, wenn nicht als solche gekenzeichnet, gelöscht.
+                %li Starte keine "Flame Wars". Dies beinhaltet das Erstellen von Posts die eine Person beleidigen oder sie dazu anstiften einen "Flame War" zu starten. Hasstiraden oder dergleichen sind ebenfalls nicht erlaubt.
+                %li Alle Posts sollten zum Thema beitragen. Unnötige Posts (Off-Topic) werden, wenn nicht als solche gekennzeichnet, gelöscht.
                 %li Wenn du denkst, ein Thread sollte geschlossen werden, nutze oc.tc/report.
-                %li Bilder, die nicht zum Thema relevant sind werden gelöscht.
-                %li "Bumpe" keine Threads. Das heißt du sollt keine Posts erstellen, nur damit dieser Thread wieder auf die Startseite der Foren gelangt.
-                %li Alle Persönlichen Konflikte müssen privat (z.b über Skype) besprochen werden. Nutze das Forum nicht für solche Angelegenheiten
+                %li Bilder, die nicht relevant für das Thema sind, werden gelöscht.
+                %li "Bumpe" keine Threads. Das heißt, du sollt keine Posts erstellen, nur damit dieser Thread wieder auf die Startseite der Foren gelangt.
+                %li Alle persönlichen Konflikte müssen privat (z.B. über Skype) besprochen werden. Nutze das Forum nicht für solche Angelegenheiten.
 
     .page-header
         %h2 C. Mumble
     .row
         .span12
             %ol
-                %li Gebe dich nicht als jemand anders als du in Mumble aus.
-                %li Dein Mumble-Nickname sollte deine Minecraft-Name sein, oder eine leicht zu erkennende Variation.
-                %li Spamme keine Sprachnachrichten, d.h drücke nicht schnell auf den "mute" knopf oder ähnliches.
+                %li Gib dich nicht als jemand anders als du in Mumble aus.
+                %li Dein Mumble-Nickname sollte dein Minecraft-Name sein, oder eine leicht zu erkennende Variation.
+                %li Spamme keine Sprachnachrichten, d.h. drücke nicht schnell auf den "mute" Knopf oder ähnliches.
 
     .page-header
         %h2 D. Im Spiel
     .row
         .span12
             %ol
-                %li Schreibe keine Nachrichten die Spieler auffordern das Team oder den Server zu verlassen .
-                %li Fordere niemanden dazu auf, jemand anders zu melden mit /report.
-                %li Unterstelle niemandem Öffentlich das er ein "Hacker" ist. Wenn du glaubst jemand "hackt" oder bricht die Regeln in irgend einer Weise, nutze /report <Wen> <Warum>
-                %li Verlinke keine Öffentliche oder Private Server, die nicht Teil des "Overcast Network" sind. (Du kannst jedoch /msg <Spieler> <Nachricht> nutzen, um jemanden einen Server vorzuschlagen, z.b. einem Freund).
+                %li Schreibe keine Nachrichten die Spieler auffordern das Team oder den Server zu verlassen.
+                %li Fordere niemanden dazu auf, jemand anders mit /report zu melden.
+                %li Unterstelle niemandem öffentlich das er ein "Hacker" ist. Wenn du glaubst,dass jemand "hackt" oder in irgendeiner Weise die Regeln bricht, nutze /report <Wen> <Warum>
+                %li Verlinke keine öffentlichen oder privaten Server, die nicht Teil des "Overcast Network" sind. (Du kannst jedoch /msg <Spieler> <Nachricht> nutzen, um jemanden einen Server vorzuschlagen, z.B. einem Freund).
                 %li Dein Nutzername sollte angemessen sein, und nicht vulgär oder angreifend. Falls dein Nutzername diese Kriterien nicht erfüllt, werden wir dich fragen, ob du nicht einen anderen Nutzernamen nutzen kannst.
                 %span.label.label-warning Beachte
                 %small Alle Nachrichten und eingegebene Kommandos werden gespeichert.
@@ -76,29 +76,29 @@
             %ol
                 %li Spieler dürfen nicht:
                 %ul
-                    %li "Combat loggen". "Combat loggen" ist definiert wie folgt: Absichtlich das Spiel verlassen, um einem Tod zu entgehen. (Du kannst das Spiel verlassen, wenn der Tod durch einen "Team-griefer" verursacht würde)
-                    %li Bugs in Minecraft ausnutzen um einen Vorteil den anderen Spielern gegenüber zu erlangen. Dies beinhaltet folgendes: Blöcke dort plazieren wo das Plugin es eigentlich nicht erlaubt um auf diesem Block zu laufen, Eine "X-Ray" Maschine zu bauen mit Glowstone oder TNT.
+                    %li "Combat loggen". "Combat loggen" ist definiert wie folgt: Absichtlich das Spiel verlassen, um einem Tod zu entgehen. (Du kannst das Spiel verlassen, wenn der Tod durch einen "Team-Griefer" verursacht würde)
+                    %li Bugs in Minecraft ausnutzen, um einen Vorteil den anderen Spielern gegenüber zu erlangen. Dies beinhaltet folgendes: Blöcke dort plazieren wo das Plugin es eigentlich nicht erlaubt um auf diesem Block zu laufen, eine "X-Ray" Maschine mit Glowstone oder TNT zu bauen.
                 %li In "Blitz" oder "Ghost Squadron" Spielen ist es verboten:
                 %ul
                     %li Die Partie zu verlängern in dem man sich versteckt oder den Kampf vermeidet.
-                %li Observierer dürfen keine Taktischen Informationen an die spielenden Teams weitergeben. Taktische Informationen beinhaltet folgendes.
+                %li Beobachter (Observer) dürfen keine taktischen Informationen an die spielenden Teams weitergeben. Taktische Informationen beinhaltet Folgendes:
                 %ul
                     %li Das Verraten der Position eines Spielers
                     %li Das Verraten des Wollen-Trägers auf einer "Capture-the-Wool" map.
-                %li Bitte nutze einen nicht vulgären oder sonstig unpassenden Skin. Du wirst gebannt bis du einen neuen Skin hast.
-                %li Attackiere nicht direkt den Spawn des Gegners (Der Spawnpunkt ist definiert als der Punkt in dem der Gegner das Spielfeld betritt)
+                %li Bitte nutze keinen vulgären oder sonstig unpassenden Skin. Du wirst gebannt, bis du einen neuen Skin hast.
+                %li Attackiere nicht direkt den Spawn des Gegners (Der Spawnpunkt ist definiert, als der Punkt in dem der Gegner das Spielfeld betritt)
                 %ul
                     %li Das folgende gilt as "Spawnkilling" und ist verboten:
                     %ul
                         %li Den direkten (Schwert) oder indirekten (Bogen) Angriff auf den Spawn des Gegners.
-                        %li TNT Kannonen auf den Spawn des Gegners  richten. (Die Kannone muss umgebaut werden, sollte sie den Spawn treffen)
+                        %li TNT Kanonen auf den Spawn des Gegners  richten. (Die Kanone muss umgebaut werden, sollte sie den Spawn treffen)
                         %li Jegliche Aktion die den Spawnbereich unpassierbar machen.
                         %li Das Runterfallen lassen von TNT in einen Spawn.
                         %li "Camping" einen Spawnpunkt in dem man neben dem Spawn auf neu spawnende Spieler wartet.
                     %li Ausgenommen sind:
                     %ul
-                        %li Unabsichtliches Treffen des Spawn mit einer TNT-Kannone (Nur wenn der Spieler die Kannone dann umbaut).
-                        %li Kämpfen gegen neu gespawnte Spieler die auf einen zurennen, ohne sich Ausrüstung zu besorgen.
+                        %li Unabsichtliches Treffen des Spawns mit einer TNT-Kanone (Nur wenn der Spieler die Kanone dann umbaut).
+                        %li Kämpfen gegen neu gespawnte Spieler, die auf einen zurennen, ohne sich Ausrüstung zu besorgen.
                         %li Kämpfen gegen Spieler wenn das "objective" der Map nah am Spawnpunkt liegt.
                 %span.label.label-warning Beachte
                 %small Diese "Spawnkilling" Regeln gelten nicht auf "TDM" oder "Blitz" Spielen.
@@ -108,7 +108,7 @@
     .row
         .span12
             %ol
-                %li Jegliche Modifikation des Clients die dir einen unfairen Vorteil gegenüber anderen geben ist illegal.
+                %li Jegliche Modifikation des Clients, welche dir einen unfairen Vorteil gegenüber anderen geben ist illegal.
                 %li
                     %i Die folgenden Mods sind explizit erlaubt:
                 %ul.unstyled
@@ -120,15 +120,15 @@
                         ArmorStatusHUD/StatusEffectHUD
                     %li
                         %i.icon-ok
-                        Toggle-crouch, vorraugesetzt, es erlaubt einem nicht zu schleichen während man schreibt, oder in Inventare oder Menüs sieht
+                        Toggle-crouch, vorraugesetzt, es erlaubt nicht zu schleichen während man schreibt, oder in Inventare oder Menüs sieht
                     %li
                         %i.icon-ok
                         Texture Packs, die nicht in die Katergorie "Ausdrücklich verboten" fallen
                     %li
                         %i.icon-ok
-                        Minimaps ausser den unten Beschriebenen
+                        Minimaps außer den unten Beschriebenen
                 %li
-                    %iDie folgenden Mods sind explizit verboten während des Spiels:
+                    %iDie folgenden Mods sind während des Spiels explizit verboten:
                 %ul.unstyled
                     %li
                         %i.icon-remove
@@ -144,7 +144,7 @@
                         Automatische Werkzeugauswähler
                     %li
                         %i.icon-remove
-                        Minimaps, die Entitypositionen, oder Höhlen/den Untergrund abbilden
+                        Minimaps, die Entitypositionen, Höhlen und/oder den Untergrund abbilden
                     %li
                         %i.icon-remove
                         Röngten/X-Ray mods
@@ -158,8 +158,8 @@
                         %i.icon-remove
                         Fly mods
                 %li
-                    %i Für Modifikationen, bei denen dir nicht klar ist ob sie illegal sind, frag einen Moderator bevor du sie nutzt.
-                %li Observierer sind nicht an diese Regeln gebunden.
+                    %i Für Modifikationen, bei denen dir nicht klar ist, ob sie illegal sind, frag einen Moderator, bevor du sie nutzt.
+                %li Beobachter (Observer) sind nicht an diese Regeln gebunden.
                 %span.label.label-warning Beachte
                 %small Dieser Abschnitt wird manchmal aktualisiert. Es wird erwartet, das du immer auf dem neusten Stand bist.
 
@@ -168,21 +168,21 @@
     .row
         .span12
             %ol
-                %li "Team griefing" ist verboten, und ist definiert als jegliche Aktion die deinem Team in irgendeiner Weise schadet.
+                %li "Team griefing" ist verboten, und ist definiert als jegliche Aktion, die deinem Team in irgendeiner Weise schadet.
                 %li
                     %i Das Folgende ist "Team Griefing":
                 %ol{:type => "a"}
-                    %li Das plazieren oder aktivieren von TNT neben Spielkameraden oder wichtigen Punkten auf der Map, z.b. die Ausrüstungskisten
-                    %li Das Zerstören von Werkbanken des Teams.
-                    %li "Teamkilling" (z.b. durch das Entfernen eines Blocks unter einem Teamkameraden, was ihn zum Fall bringt)
-                    %li Das Nutzen oder Verändern einer Kannone, die man nicht selber gebaut hat.
-                    %li Dem anderen Team helfen oder mit ihnen zusammen anstatt gegen sie zu arbeiten.
+                    %li Das plazieren oder aktivieren von TNT neben Spielkameraden oder wichtigen Punkten auf der Map, z.B. die Ausrüstungskisten
+                    %li Das Zerstören von Werkbänken des Teams.
+                    %li "Teamkilling" (z.B. durch das Entfernen eines Blocks unter einem Teamkameraden, was ihn zum Fall bringt)
+                    %li Das Nutzen oder Verändern einer Kanone, die man nicht selber gebaut hat.
+                    %li Dem anderen Team helfen oder mit ihnen zusammen, anstatt gegen sie zu arbeiten.
                 %li
                     %i Das Folgende wird als rücksichtslos und nicht empfehlenswert betrachtet (Du wirst für das Folgende verwarnt, aber nicht direkt bestraft):
                 %ol{:type => "a"}
-                    %li Das bauen von Säulen aus TNT in der eigenen Basis.
-                    %li Das mitnehmen von allen oder fast allen Wollblöcken auf einer "Capture the Wool" Map, es sei denn es ist nur noch ein Wollblock übrig
-                %li Jeglichte Aktion die hier nicht gelistet ist, aber trotzdem dein Team daran hindert zu gewinnen wird als "Team Griefing" bezeichnet und ebenfalls bestraft.
+                    %li Das Bauen von Säulen aus TNT in der eigenen Basis.
+                    %li Das mitnehmen von allen oder fast allen Wollblöcken auf einer "Capture the Wool" Map, es sei denn, es ist nur noch ein Wollblock übrig.
+                %li Jeglichte Aktion, die hier nicht gelistet ist, aber trotzdem deinem Team am Gewinnen hindert wird als "Team Griefing" bezeichnet und ebenfalls bestraft.
                 %span.label.label-warning Beachte
                 %small
                     Spieler dürfen sich
@@ -202,18 +202,18 @@
     .row
         .span12
             %ol
-                %li Spieler werden bei Regelverstoss entweder verwarnt oder bestraft
+                %li Spieler werden bei Regelverstoß entweder verwarnt oder bestraft.
                 %li Wenn ein Spieler bestraft wird, wird er entweder ge-kickt, für 7 Tage gebannt oder Permanent gebannt. Dies ist abhängig von der Anzahl der bereits vorhandenen Bestrafungen.
-                %li Bei besonders schwerwiegenden Regelverstößen, Einschliesslich das nutzen von "Hacking Clients" oder Extremem "Team Grief", wird der Spieler sofort und ohne vorherige Warnung Permanent gebannt.
+                %li Bei besonders schwerwiegenden Regelverstößen, Einschliesslich das nutzen von "Hacking Clients" oder extremem "Team Grief", wird der Spieler sofort und ohne vorherige Warnung Permanent gebannt.
                 %li Spieler mit vielen Warnungen für den gleichen Regelverstoss können deswegen Temporär gebannt werden.
-                %li Das nutzen eines Zweit-accounts während der Erst-Account gebannt ist wird nicht gestattet, und alle Zweit-Accounts werden sofort auch gebannt. Die Zweit-accounts werden für immer Permanent gebannt werden, auch wenn der Bann auf dem Erst-account abgelaufen ist, und die Länge des Banns auf dem Erst-account wird verdreifacht.
+                %li Das Nutzen eines Zweit-Accounts während der Erst-Account gebannt ist wird nicht gestattet, und alle Zweit-Accounts werden sofort auch gebannt. Die Zweit-Accounts werden für immer Permanent gebannt werden, auch wenn der Bann auf dem Erst-Account abgelaufen ist, und die Länge des Banns auf dem Erst-Account wird verdreifacht.
                 %li Bei extremen Fällen von dieser "Bann-Flucht" werden alle Accounts Permanent gebannt.
                 %li
-                    Spieler die gebannt wurden, werden auch für die Länge des Banns aus den Foren verbannt. Für den Fall das dein Bann länger als 7 Tage anhält, kontaktiere bitte
+                    Spieler, die gebannt wurden, werden auch für die Länge des Banns aus den Foren verbannt. Für den Fall, dass dein Bann länger als 7 Tage anhält, kontaktiere bitte
                     %a{:href => "mailto:support@oc.tc"} support@oc.tc
                     um die genaue Länge des Forum-Banns rauszufinden.
                 %li Spieler, die gegen die Verhaltensregeln in Mumble verstoßen werden entweder vom Mumble Server gekickt oder gebannt.
-                %li Spieler die auf einem der angebotenen Dienste die Regeln brechen (Egal ob Im Spiel, in den Foren, oder in Mumble) können auch von allen anderen Diensten gebannt werden.
+                %li Spieler, die auf einem der angebotenen Dienste die Regeln brechen (Egal ob Im Spiel, in den Foren, oder in Mumble), können auch von allen anderen Diensten gebannt werden.
                 %li
                     Gegen alle im Spiel ausgehändigten Banns kann unter
                     = succeed '.' do
@@ -234,4 +234,4 @@
                 %li Bei Regeländerung werden die Spieler benachrichtigt.
                 %li Die Spieler sind dafür verantwortlich mit den aktualisierten Regeln vertraut zu sein.
                 %li Neue Regeln treten eine Woche nach der Bekanntgabe in Kraft.
-                %li Die "Overcast Network" Administration behält sich das Recht vor, jeden Spieler aus jeglichem Grund ohne Benachrichtigung zu verbannen.
+                %li Die "Overcast Network" Administration behält sich das Recht vor, jeden Spieler aus jeglichem Grund und ohne Benachrichtigung von jeglichem "Overcast Network" Dienst zu verbannen.


### PR DESCRIPTION
Most of them were typos and grammar mistakes.
