### PR TITLE
Added examples of minimaps containing entity radars

### DIFF
--- a/en.haml
+++ b/en.haml
@@ -145,7 +145,7 @@
                         Automatic tool selectors
                     %li
                         %i.icon-remove
-                        Minimaps that show entity positions, or show caves/underground.
+                        Minimaps that show entity positions, or show caves/underground. (e.g.: Zan's, RadarBro)
                     %li
                         %i.icon-remove
                         X-rays


### PR DESCRIPTION
Added the following examples;
- Zan's Minimap
- RadarBro

to the list of minimaps not allowed.
