### PR TITLE
Fix some incorrect Dutch Translation

### DIFF
--- a/nl.haml
+++ b/nl.haml
@@ -2,7 +2,7 @@
     .page-header
         %h1
             Regels
-            %small Voor het laatst geüpdatet op 3 mei, 2014
+            %small Voor het laatst geüpdatet op 6 mei, 2014
             = render "select"
     .row
         .span12
@@ -60,9 +60,9 @@
             %ol
                 %li Stuur geen berichten naar andere mensen die ervoor zorgen dat ze het spel verlaten of de verbinding met de server verbreken. Het is bijvoorbeeld verboden mensen aan te sporen om Alt+F4 te drukken.
                 %li Vertel andere spelers niet wie ze moeten reporten, tenzij je uitlegt hoe ze moeten reporten.
-                %li Beschuldig iemand niet van hacken in het openbaar als je denkt dat iemand hackt of een regel breekt. Report diegene met het command /report: (/report <speler> <reden>)
+                %li Beschuldig iemand niet van hacken in het openbaar als je denkt dat iemand hackt of een regel breekt. Report diegene met het command /report: (/report [speler] [reden])
                 %li Reclame maken voor andere servers die niet van Overcast Network zijn, is niet toegestaan. Je zal verbannen worden als je dit doet.
-                %li Je mag niet linken naar andere servers of mensen vertellen dat ze een bepaalde server moeten joinen. Als iemand erom vraagt, stuur diegene dan een privébericht met /msg of /tell (/msg <speler> <bericht>) en informeer ze met deze regel.
+                %li Je mag niet linken naar andere servers of mensen vertellen dat ze een bepaalde server moeten joinen. Als iemand erom vraagt, stuur diegene dan een privébericht met /msg of /tell (/msg [speler] [bericht]) en informeer ze met deze regel.
                 %li Je Minecraft gebruikersnaam moet normaal zijn en niet respectloos, racistisch, seksueel of intimiderend. Je zal verbannen worden als je gebruikersnaam één of meerdere van deze criteria overschrijdt.
                 %span.label.label-warning Notitie
                 %small Alle chatberichten en -commands worden opgeslagen en kunnen teruggevonden worden.
@@ -127,7 +127,7 @@
                         Texture packs die niet vallen onder valsspelen (x-ray packs, enzovoort)
                     %li
                         %i.icon-ok
-                        Minimaps, behalve degene genoteerd hieronder
+                        Minimaps, behalve degenen genoteerd hieronder
                 %li
                     %i De volgende mods zijn verboden tijdens het spelen:
                 %ul.unstyled
@@ -136,7 +136,7 @@
                         Inventory sorteerders
                     %li
                         %i.icon-remove
-                        Auto-sprint. Ook een "sprint-key" gebruiken inplaats van dubbel w (voor qwerty) of z (voor azerty) is verboden.
+                        Auto-sprint. Ook een "sprint-key" gebruiken in plaats van dubbel w (voor qwerty) of z (voor azerty) is verboden.
                     %li
                         %i.icon-remove
                         Mods die namen duidelijker maken of namen van spelers die shiften, nog steeds tonen.


### PR DESCRIPTION
I changed some incorrect words. The commands doesn't display on the website when using < and >.
