### PR TITLE
Vectorized ✓ and ⨉'s on Rule List

### DIFF
--- a/da.haml
+++ b/da.haml
@@ -105,55 +105,55 @@
                 %li De følgende modifikationer er tydeligt lovligt at bruge:
                 %ul.unstyled
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Optifine
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         ArmorStatusHUD/StatusEffectHUD
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Toggle-crouch that does not allow crouching while typing, looking through inventory, or in any menus
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Texture-packs der ikke falder under nogen "tydeligt ulovlige" kategorier
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Minimap/kort på skærmen, undtagen hvis den viser spillere og/elle undergrunden
                 %li De følgende modifikationer er tydeligt forbudte under spillet:
                 %ul.unstyled
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Inventory Sorters, modifikationer der sorterer dit inventar
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Modifikationer der afslører eller forstørrer navnene på spillere
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Automatiske våben/værktøjs-vælgere
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Minimap/kort der viser spiller positioner og/eller undergrunden
                         Automatic tool selectors
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         X-rays, røntgen-syn
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Auto-hitter, som selv slår for dig
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Aimbot, som selv sigter for dig
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Flyve modifikationer, som gør at du kan flyve
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Damage/Health Indicator
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         SmartMoving
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Better Sprinting
                 %li For any other mods, email support@oc.tc for confirmation before using it.
                 %li Tilskuere er ikke bundet af disse restriktioner

--- a/de.haml
+++ b/de.haml
@@ -104,55 +104,55 @@
                 %li The following modifications are explicitly permitted during gameplay:
                 %ul.unstyled
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Optifine
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         ArmorStatusHUD/StatusEffectHUD
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Toggle-crouch that does not allow crouching while typing, looking through inventory, or in any menus
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Texture Packs, die nicht in die Kategorie "Ausdrücklich verboten" fallen
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Minimaps, außer den unten beschriebenen
                 %li
                     %iDie The following modifications are explicitly prohibited during gameplay:
                 %ul.unstyled
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Inventory Sorters
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Mods, die Nametags vergrößern oder besser lesbar machen
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Automatische Werkzeugauswähler
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Minimaps, die Entitypositionen, Höhlen und/oder den Untergrund abbilden
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Röngten/X-Ray mods
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Auto-hitters
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Aimbots
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Fly mods
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Damage/Health Indicator
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         SmartMoving
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Better Sprinting
                 %li For any other mods, email support@oc.tc for confirmation before using it.
                 %li Beobachter (Observer) sind nicht an diese Regeln gebunden.

--- a/en.haml
+++ b/en.haml
@@ -104,54 +104,54 @@
                 %li The following modifications are explicitly permitted during gameplay:
                 %ul.unstyled
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Optifine
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         ArmorStatusHUD/StatusEffectHUD
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Toggle-crouch that does not allow crouching while typing, looking through inventory, or in any menus
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Texture packs that do not fall under any "explicitly prohibited" category
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Minimaps except as specified below
                 %li The following modifications are explicitly prohibited during gameplay:
                 %ul.unstyled
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Inventory Sorters
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Mods that expose or enlarge the name-tags of players
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Automatic tool selectors
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Minimaps that show entity positions, or show caves/underground.
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         X-rays
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Auto-hitters
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Aimbots
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Fly mods
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Damage/Health Indicator
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         SmartMoving
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Better Sprinting
                 %li For any other mods, email support@oc.tc for confirmation before using it.
                 %li Observers are not bound to these restrictions.

--- a/es.haml
+++ b/es.haml
@@ -104,53 +104,53 @@
                 %li Los siguientes mods están explícitamente permitidos durante el juego:
                 %ul.unstyled
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Optifine
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         ArmorStatusHUD/StatusEffectHUD
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Toggle-crouch that does not allow crouching while typing, looking through inventory, or in any menus
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Texturas que no entran en ninguna categoría "prohibida expresamente"
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Minimaps excepto por los especificados a continuación.
                 %li Los siguientes mods estan explícitamente prohibidos al jugar:
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Ajustadores de inventario
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Mods que exponen o amplían los campos del nombre de los jugadores.
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Selectores de herramientas automáticos.
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Minimapas que muestren las posiciones de entidad, o que muestren cuevas subterráneas.
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Rayos X "X-rays"
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Auto Golpeadores "Auto-hitters"
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         "Aimbots"
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Mods para volar
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Damage/Health Indicator
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         SmartMoving
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Better Sprinting
                 %li Para otros mods, pida a un miembro del personal la confirmación antes de usarlos.
                 %li Los observadores no están sujetos a estas restricciones

--- a/fr.haml
+++ b/fr.haml
@@ -104,54 +104,54 @@
                 %li Les mods suivants sont permis pendant les matchs : (les noms sont en anglais)
                 %ul.unstyled
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Optifine
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         ArmorStatusHUD/StatusEffectHUD
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Toggle-crouch that does not allow crouching while typing, looking through inventory, or in any menus
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Les packs de Textures qui ne sont pas compris dans la section “interdits”.
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Les minimaps, ou mini-cartes, sauf si spécifié dans “interdits”.
                 %li Les mods suivants sont absolument interdits pendant les matchs :
                 %ul.unstyled
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Inventory Sorters - Organisateur d’inventaire
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Les mods qui surexposent ou agrandissent les noms des joueurs.
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Les mods qui choisissent automatiquement l’outil nécessaire au moment de casser un bloc.
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Les minimaps ou mini-cartes qui montrent la position des entités ainsi que la position des souterrains et des cavernes.
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         X-rays
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Auto-hitters - Mods qui frappent automatiquement les joueurs.
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Aimbots - Mods qui visent automatiquement les joueurs.
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Fly mods - Mods qui permettent de voler dans les airs.
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Damage/Health Indicator
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         SmartMoving
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Better Sprinting
                 %li Pour tout autre mod, merci de demander à un membre du staff s’il est autorisé avant de l’utiliser.
                 %li Les Observateurs ne sont pas soumis à ces restrictions.

--- a/it.haml
+++ b/it.haml
@@ -105,54 +105,54 @@
                 %li Le seguenti mod sono esplicitamente permesse durante il gioco:
                 %ul.unstyled
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Optifine;
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         ArmorStatusHUD/StatusEffectHUD;
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Toggle-crouch that does not allow crouching while typing, looking through inventory, or in any menus
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Pacchetti di risorse che non ricadono sotto alcuna categoria proibita;
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Minimappe eccetto quanto specificato sotto;
                 %li Le seguenti mod sono esplicitamente proibite durante il gioco:
                 %ul.unstyled
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Ordinatori dell'inventario;
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Mod che rendono più visibile il nome dei giocatori;
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Selettori automatici degli strumenti;
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Minimappe che visualizzano la posizione dei giocatori o sottoterra;
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         X-ray;
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Auto-hitter;
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Aimbot;
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Fly mod;
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Damage/Health Indicator;
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         SmartMoving;
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Better Sprinting;
                 %li For any other mods, email support@oc.tc for confirmation before using it.
                 %span.label.label-warning Nota

--- a/ko.haml
+++ b/ko.haml
@@ -102,57 +102,57 @@
                 %li 사용 가능한 모드:
                 %ul.unstyled
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         옵티파인
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         ArmorStatusHUD/StatusEffectHUD
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Toggle-crouch that does not allow crouching while typing, looking through inventory, or in any menus
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         모든 "명시 적으로 금지"범주에 속하지 않는 텍스처 팩
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         미니맵
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         한글패치
                 %li 금지되는 모드:
                 %ul.unstyled
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         자동으로 인벤토리를 정리하는 모드
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         플레이어의 이름 태그를 커지게 하는 모드
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         자동 인벤토리 핫키
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         지하 등을 보여주는 미니맵.
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         엑스레이
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         자동 타자기
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         자동조준 모드
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         플라이 모드
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Damage/Health Indicator
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         SmartMoving
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Better Sprinting
                 %li For any other mods, email support@oc.tc for confirmation before using it.
                 %li 관찰자는 상관없습니다.

--- a/nl.haml
+++ b/nl.haml
@@ -105,54 +105,54 @@
                 %li De volgende mods zijn toegestaan tijdens het spelen:
                 %ul.unstyled
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Optifine
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         ArmorStatusHUD/StatusEffectHUD
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Toggle-crouch that does not allow crouching while typing, looking through inventory, or in any menus
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Texture packs die niet vallen onder valsspelen (x-ray packs, enzovoort)
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Minimaps, behalve degenen genoteerd hieronder
                 %li De volgende mods zijn verboden tijdens het spelen:
                 %ul.unstyled
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Inventory sorteerders
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Mods die namen duidelijker maken of namen van spelers die shiften, nog steeds tonen.
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Automatische toolkeuzeschakelaar
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Minimaps die entiteiten weergeven of grotten/tunnels weergeven.
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         X-rays
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Auto-hitters
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Aimbots
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Fly mods
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Damage/Health Indicator
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         SmartMoving
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Better Sprinting
                 %li For any other mods, email support@oc.tc for confirmation before using it.
                 %li Toeschouwers hoeven zich niet aan deze regels te houden.

--- a/ru.haml
+++ b/ru.haml
@@ -104,54 +104,54 @@
                 %li Нижеперечисленные моды разрешены во время геймплея на сервере:
                 %ul.unstyled
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Optifine
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Показатель прочности вашей брони HUD/показатель эффектов в углу экрана HUD
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Toggle-crouch that does not allow crouching while typing, looking through inventory, or in any menus
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Tекстур паки, которые не попадают ни под одну "прямо запрещены" категории.
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Миникарты за исключением случаев, указанных ниже.
                 %li Следующие моды строго запрещены во время геймплея:
                 %ul.unstyled
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Сортировка инвенторя
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Mоды, которые раскрывают или увеличивают ники других игроков.
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Автоматические сортировщики инструментов
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Миникарты, которые показывают мобов, пещеры или подземные ходы.
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         X-rays (рентген)
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Килл-аура
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Aimbots (аим-бот)
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Моды, позволяющие летать.
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Damage/Health Indicator
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         SmartMoving
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Better Sprinting
                 %li For any other mods, email support@oc.tc for confirmation before using it.
                 %li Зрители не связаны с этими ограничениями.

--- a/sv.haml
+++ b/sv.haml
@@ -105,54 +105,54 @@
                 %li Följande modifikationer är uttryckligen tillåtna medans man spelar:
                 %ul.unstyled
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Optifine
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         ArmorStatusHUD/StatusEffectHUD
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Toggle-crouch that does not allow crouching while typing, looking through inventory, or in any menus
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Texturpaket (Texture/Resource packs) som inte faller under någon "uttryckligen förbjudna" kategori
                     %li
-                        %i.icon-ok
+                        %i.fa.fa-check
                         Miniatyrkartor (Minimaps) utom såsom angivet nedan
                 %li Följande modifikationer är uttryckligen förbjudna medans man spelar:
                 %ul.unstyled
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Utrustningssorterare (Inventory Sorters)
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Modifikationer som avslöjar eller förstorar spelares namnplåtar
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Automatiska verktygväljare (Auto Switcher)
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Miniatyrkartor (Minimaps) som visar entitetpositioner, eller visar grottor/underjorden.
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Röntgen (X-ray)
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Automatiska slagare (Auto-hitters)
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         "Aimbots"
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Flygmodifikationer
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Damage/Health Indicator
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         SmartMoving
                     %li
-                        %i.icon-remove
+                        %i.fa.fa-times
                         Better Sprinting
                 %li For any other mods, email support@oc.tc for confirmation before using it.
                 %li Åskådare är inte bundna till dessa begränsningar.


### PR DESCRIPTION
The two icons were images and weren't retina compatible which means they look quite bad. I used the already included Font Awesome and switched them to vector files.

Before

![screen shot 2014-08-23 at 7 48 32 pm](https://cloud.githubusercontent.com/assets/1449259/4022210/9cc2449e-2b20-11e4-810e-485f02560e0e.png)

After

![screen shot 2014-08-23 at 7 48 42 pm](https://cloud.githubusercontent.com/assets/1449259/4022211/9cc687b6-2b20-11e4-9140-62bcd5bb1abb.png)
