### PR TITLE
Fix incorrect Spanish translation

### DIFF
--- a/es.haml
+++ b/es.haml
@@ -40,24 +40,20 @@
         .span12
             %ol
                 %li
-                    Do not make topics or posts aiming to insult or provoke other people or groups,
-                    and do not promote or encourage others to make such posts.
-                %li Do not reply to topics with irrelevant, meaningless, or spammy text/images.
-                %li Do not "bump" topics by posting something that does not contribute constructively to the topic.
-                %li All personal issues must be dealt with in private. The public forums are not the place for personal conflicts.
-                %li Criticism of the work of others, both staff and the larger community, must be delivered with politeness and personal respect.
+                    No hacer tópicos o posts dirigidos a insultar o provocar a otras personas o grupos, y no promover o animar a otros a hacer tales mensajes.
+                %li No responder a temas con texto/imágenes irrelevantes, sin sentido, o spam.
+                %li No "reactivar" los temas mediante la publicación de algo que no contribuye de forma constructiva con el tema.
+                %li Todas las cuestiones personales deben tratarse en privado. Los foros públicos no son el lugar para los conflictos personales.
+                %li Las críticas al trabajo de los demás, tanto el personal y la comunidad en general, debe ser publicado con cortesía y respeto personal.
                 %li
-                    Do not make topics just to announce that you are quitting the game or the server.
-                    Exceptions may be made if you are quitting for a <em>very</em> interesting reason, like you are dying, or sailing around the world.
+                    No hacer temas sólo para anunciar que está dejando el juego o el servidor. Se pueden hacer excepciones si usted está dejando de jugar por una razón muy interesante, como si te estás muriendo, o navegando alrededor del mundo.
                 %li
-                    Announcements about dramatic events befalling other players must include a verifiable source for the information.
-                    If we cannot easily verify the story, the topic may be removed.
-                    Deliberate hoaxes of this nature are considered very serious infractions.
+                    Los anuncios sobre acontecimientos dramáticos que acontecen a otros jugadores deben incluir una fuente comprobable para la información. Si fácilmente no podemos verificar la historia, el tópico puede ser removido. Las bromas pesadas deliberadas de esta naturaleza son consideradas infracciones muy serias.
                 %li
-                    Do not reply to a topic that you feel is violating the rules,
-                    %a{:href => "/report"}submit a report
-                    instead. Intentionally lying in a report is considered an infraction.
-                %li Do not abuse HTML in the forums or personal profiles in a way that makes navigation difficult, causes extreme browser lag, or exceeds the preset boundaries.
+                    No repliegue un tópico que usted siente que viola las reglas, en lugar de eso
+                    %a{:href => "/report"}presente un reporte
+                    Mentir intencionadamente en un informe es considerado una infracción.
+                %li No abuse de HTML en los foros o perfiles personales de una manera que hace la navegación difícil, causa el retraso de navegador extremo, o excede los límites preestablecidos.
                 %small.label.label-warning Nota
                 %small Tu perfil o información de contacto puede ser borrada sin previo aviso.
     .page-header
@@ -67,7 +63,7 @@
             %ol
                 %li No suplantes a otros jugadores en Mumble.
                 %li Tu nombre en Mumble debe ser tu nombre en el juego o alguna variación fácil de identificar.
-                %li No repitas acciones que envíen mensajes a otros (como spammear el botón de mute, deafen or desconectarse y conectarse repetídamente)
+                %li No repitas acciones que envíen mensajes a otros (como spammear el botón de mute, ensordecer o desconectarse y conectarse repetídamente)
     .page-header
         %h2 D. Comportamiento en el Servidor
     .row
@@ -90,7 +86,7 @@
     .row
         .span12
             %ol
-                %li Los jugadores no deben abusar de glitches o errores. Esto incluye, pero no se limita a, poner bloques para acceder a áreas restringidas por el plugin, crer un efecto de "x-ray", y que causen invicibilidad.
+                %li Los jugadores no deben abusar de glitches o errores. Esto incluye, pero no se limita a, poner bloques para acceder a áreas restringidas por el plugin, crear un efecto de "x-ray", y que causen invisibilidad.
                 %li En una partida de Blitz o Ghost Squadron, los jugadores no deben prolongar el juego evitando el combate y/o escondiéndose en lugares inaccesibles o difíciles de llegar.
                 %li Los espectadores nunca deben ofrecer información táctica a los jugadores o intencionadamente interrumpir la jugabilidad. La información táctica incluye, pero no se limita a:
                 %ol{:type => "a"}
@@ -237,5 +233,5 @@
             %ol
                 %li Estas reglas están sujetas a cambiar con aviso.
                 %li Los jugadores son responsables de estar al tanto de los cambios en las normas.
-                %li Hay un periodo de gracia de una semana para que los cambios en las normas entren en vigor.
+                %li Hay un período de gracia de una semana para que los cambios en las normas entren en vigor.
                 %li La Administración de Overcast Network se mantiene el derecho a banear o desbanear a cualquier jugador de cualquiera de los servicios de Overcast Network por cualquier razón sin aviso.

--- a/es.haml
+++ b/es.haml
@@ -86,7 +86,7 @@
     .row
         .span12
             %ol
-                %li Los jugadores no deben abusar de glitches o errores. Esto incluye, pero no se limita a, poner bloques para acceder a áreas restringidas por el plugin, crear un efecto de "x-ray", y que causen invisibilidad.
+                %li Los jugadores no deben abusar de glitches o errores. Esto incluye, pero no se limita a, poner bloques para acceder a áreas restringidas por el plugin, crear un efecto de "x-ray", y que causen invencibilidad.
                 %li En una partida de Blitz o Ghost Squadron, los jugadores no deben prolongar el juego evitando el combate y/o escondiéndose en lugares inaccesibles o difíciles de llegar.
                 %li Los espectadores nunca deben ofrecer información táctica a los jugadores o intencionadamente interrumpir la jugabilidad. La información táctica incluye, pero no se limita a:
                 %ol{:type => "a"}


### PR DESCRIPTION
Errors: B. english rules
           C. says "deafen" and the translation is "ensordecer"
           E. says "crer" it's "crear" and says "invicibilidad" and it's "invencibilidad"
           J. says "periodo" and it is "período"