### PR TITLE
Grammatical and formal revision of German translation

### DIFF
--- a/de.haml
+++ b/de.haml
@@ -2,7 +2,7 @@
     .page-header
         %h1
             Regeln
-            %small Zuletzt geändert am January 25, 2015
+            %small Zuletzt geändert am 21. Februar 2015
             = render "select"
     .row
         .span12
@@ -10,7 +10,7 @@
             %span
             Diese Regeln gelten auf
             %b allen von
-            "Overcast Network" angebotenen Diensten.
+            “Overcast Network” angebotenen Diensten.
 
     .page-header
         %h2
@@ -18,19 +18,19 @@
     .row
         .span12
             %ol
-                %li Bitte bewahre eine angenehme Atmosphäre. Sei respektvoll zu anderen und nutze deinen Verstand. Exzessives Schimpfen, Unfreundlichkeit und Belästigung anderer wird nicht toleriert.
-                %li Versuche korrekte Grammatik und Rechtschreibung einzuhalten (Englisch und andere Sprachen).
+                %li Bitte bewahre eine angenehme Atmosphäre. Sei respektvoll zu anderen und nutze deinen Verstand. Exzessives Schimpfen, Unfreundlichkeit und Belästigung anderer werden nicht toleriert.
+                %li Versuche, korrekte Grammatik und Rechtschreibung einzuhalten (Englisch und andere Sprachen).
                 %li Kein Spam im Chat.
                 %li Verlinke keines der folgenden Dinge:
                 %ol{:type => "a"}
-                    %li Pornografische Inhalte, "Schock"-Seiten, Viren oder Phishing-Seiten oder nationalsozialistische Inhalte.
+                    %li Pornografische Inhalte, „Schock“-Seiten, Viren oder Phishing-Seiten oder nationalsozialistische Inhalte.
                     %li Werbung für andere Webseiten oder Server
                     %li
                         %a{:href => "https://en.wikipedia.org/wiki/Personally_identifiable_information#Examples"} Personenbezogene Daten von anderen Spielern.
-                %li Regelverstöße, sowie die Unterstützung selbiger wird nicht toleriert.
-                %li Behaupte nicht, du wärst ein Moderator auf dem Overcast Network, wenn du keiner bist.
-                %li Sende Bugs oder dergleichen an support@oc.tc oder erstelle einen Thread in den Foren (http://oc.tc/forums); Das Ausnutzen von Bugs wird bestraft, außer du wurdest von einem Moderator angewiesen, den Bug zu demonstrieren.
-                %li Befolge alle Anweisungen eines Overcast Network Moderator. Wenn du glaubst, ein Moderator hat dich falsch angewiesen oder in die Irre geführt, sende eine Email an support@oc.tc.
+                %li Regelverstöße, sowie die Unterstützung selbiger, werden nicht toleriert.
+                %li Behaupte nicht, du seist ein Moderator auf dem Overcast Network, wenn du keiner bist.
+                %li Sende Bugs oder dergleichen an support@oc.tc oder erstelle einen Thread in den Foren (http://oc.tc/forums); das Ausnutzen von Bugs wird bestraft, außer du wurdest von einem Moderator angewiesen, den Bug zu demonstrieren.
+                %li Befolge alle Anweisungen eines Overcast Network Moderators. Wenn du glaubst, ein Moderator hat dich falsch angewiesen oder in die Irre geführt, sende eine E-Mail an support@oc.tc.
                 %span.label.label-warning Hinweis
                 %small Berate dich mit einem Moderator, bevor du einen möglicherweise als Werbung geltenden Link postest.
 
@@ -40,81 +40,80 @@
         .span12
             %ol
                 %li
-                    Do not make topics or posts aiming to insult or provoke other people or groups,
-                    and do not promote or encourage others to make such posts.
-                %li Do not make posts that mock or "predict" inflammatory comments, as they encourage users to make such comments.
-                %li Do not reply to topics with irrelevant, meaningless, or spammy text/images.
-                %li Do not "bump" topics by posting something that does not contribute constructively to the topic.
-                %li All personal issues must be dealt with in private. The public forums are not the place for personal conflicts.
-                %li Criticism of the work of others, both staff and the larger community, must be delivered with politeness and personal respect.
+                    Erstelle keine Threads um andere Spieler oder Gruppen zu beleidigen oder zu provozieren,
+                    und ermutige andere nicht, solche Posts zu machen.
+                %li Erstelle keine Posts, die inflammatorische Kommentare verspotten oder „prognostizieren“, da diese andere User dazu auffordern, solche Kommentare zu erstellen.
+                %li Antworte nicht mit irrelevanten oder unnützen Nachrichten/Bildern.
+                %li „Bumpe“ keine Threads durch Posts, die nicht konstruktiv zum Thema beitragen.
+                %li Persönliche Probleme müssen privat besprochen werden. Das Forum ist nicht der richtige Ort für diese Angelegenheiten.
+                %li Kritik an der Arbeit anderer muss höflich und mit Respekt verfasst sein.
                 %li
-                    Do not make topics just to announce that you are quitting the game or the server.
-                    Exceptions may be made if you are quitting for a <em>very</em> interesting reason, like you are dying, or sailing around the world.
+                    Erstelle keine Threads, um nur bekannt zu geben, dass du den Server oder das Spiel verlässt.
+                    Es werden Ausnahmen genehmigt, wenn ein <em>sehr</em> interessanter Grund vorliegt, zum Beispiel, dass du im Sterben liegst oder einmal um die Welt segeln willst.
                 %li
-                    Announcements about dramatic events befalling other players must include a verifiable source for the information.
-                    If we cannot easily verify the story, the topic may be removed.
-                    Deliberate hoaxes of this nature are considered very serious infractions.
+                    Threads über dramatische Ereignisse, die andere Spieler betreffen, müssen überprüfbare Quellenangaben aufweisen.
+                    Wenn wir die Richtigkeit des Berichtes nicht überprüfen können, wird der Thread gelöscht.
+                    Bei absichtlich gefälschten Berichten werden harte Strafen in Erwägung gezogen.
                 %li
-                    Do not reply to a topic that you feel is violating the rules,
-                    %a{:href => "/report"}submit a report
-                    instead. Intentionally lying in a report is considered an infraction.
-                %li Do not abuse HTML in the forums or personal profiles in a way that makes navigation difficult, causes extreme browser lag, or exceeds the preset boundaries.
-                %small.label.label-warning Note
-                %small Der Inhalt deines Profils kann ohne voherige Warnung gelöscht werden.
+                    Antworte nicht auf einen Thread oder einen Post, falls du der Meinung bist, dass dieser gegen die Regeln verstößt,
+                    %a{:href => "/report"}erstelle stattdessen einen Report. Absichtliches Lügen in einem Report wird bestraft.
+                %li Nutze das HTML in deinem Profil oder in Forenposts nicht aus, sodass es die Navigation erschwert, den Browser zum Laggen bringt oder die vorgegeben Grenzen überschreitet.
+                %small.label.label-warning Hinweis
+                %small Der Inhalt deines Profils kann ohne vorherige Warnung gelöscht werden.
 
     .page-header
         %h2 C. Mumble
     .row
         .span12
             %ol
-                %li Gib dich nicht als jemand anders als du in Mumble aus.
+                %li Gib dich in Mumble nicht als jemand anderen aus als du bist.
                 %li Dein Mumble-Nickname sollte dein Minecraft-Name sein, oder eine leicht zu erkennende Variation.
-                %li Spamme keine Sprachnachrichten, d.h. drücke nicht schnell auf den "mute" Knopf oder ähnliches.
+                %li Spamme keine Sprachnachrichten, d.h. drücke nicht schnell auf den “Mute”-Knopf oder ähnliches.
 
     .page-header
         %h2 D. Verhalten auf dem Server
     .row
         .span12
             %ol
-                %li Schreibe keine Nachrichten, die Spieler auffordern das Team oder den Server zu verlassen.
-                %li Fordere niemanden dazu auf, jemand anders mit /report zu melden.
-                %li Bitte beschuldige keine anderen Spieler öffentlich des Hackens. Falls du glaubst, dass ein Spieler hackt oder irgendeine andere Regel bricht, melde sie mit dem /report-Befehl.
-                %li Du sollst keine IPs von Servern, die nicht zum Overcast Network gehören, in den Chat schreiben. (Du kannst den /msg-Befehl benutzen um einem Spieler die IP zu schicken, falls er danach gefragt hat).
-                %li Dein Benutzername muss angemessen sein, und du könntest dazu aufgefordert werden einen anderen Account zu nutzen, falls dein Benutzername unangemessen ist. (Dies zählt nicht als Banumgehung.)
+                %li Schreibe keine Nachrichten, die Spieler dazu auffordern, das Team oder den Server zu verlassen.
+                %li Fordere niemanden dazu auf, jemand anderen mit “/report” zu melden.
+                %li Bitte beschuldige keine anderen Spieler öffentlich des Hackens. Falls du glaubst, dass ein Spieler hackt oder irgendeine andere Regel bricht, melde sie mit dem “/report”-Befehl.
+                %li Du sollst keine IPs von Servern, die nicht zum Overcast Network gehören, in den Chat schreiben. (Du kannst den “/msg”-Befehl benutzen um einem Spieler die IP zu schicken, falls er danach gefragt hat.)
+                %li Dein Benutzername muss angemessen sein, und du könntest dazu aufgefordert werden, einen anderen Account zu nutzen, falls dein Benutzername unangemessen ist. (Dies zählt nicht als Bannumgehung.)
                 %span.label.label-warning Hinweis
                 %small Alle Nachrichten und eingegebene Kommandos werden gespeichert.
                 %br
                 %span.label.label-warning Hinweis
-                %small Du kannst deinen Livestream verlinken, solange du den Link nicht "spammst", und solange er mit dem "Overcast Network" zu tun hat .
+                %small Du kannst deinen Livestream verlinken, solange du den Link nicht „spammst“, und solange er mit dem Overcast Network zu tun hat.
 
     .page-header
         %h2 E. Allgemeine Spielregeln
     .row
         .span12
             %ol
-                %li Spieler dürfen nicht bugs in Minecraft ausnutzen, um einen Vorteil den anderen Spielern gegenüber zu erlangen. Dies beinhaltet folgendes: Blöcke dort plazieren, wo das Plugin es eigentlich nicht erlaubt, um auf diesem Block zu laufen, eine "X-Ray" Maschine mit Glowstone oder TNT zu bauen.
-                %li In "Blitz" oder "Ghost Squadron"-Spielen ist es verboten die Partie zu verlängern, indem man sich versteckt oder den Kampf vermeidet.
+                %li Spieler dürfen nicht Bugs in Minecraft ausnutzen, um einen Vorteil gegenüber anderen Spielern zu erlangen. Dies beinhaltet Folgendes: Blöcke dort platzieren, wo das Plugin es eigentlich nicht erlaubt, um auf diesem Block zu laufen; eine “X-Ray”-Maschine mit Glowstone oder TNT zu bauen; und um dich unbesiegbar zu machen.
+                %li In “Blitz”- oder “Ghost Squadron”-Spielen ist es verboten, die Partie zu verlängern, indem man sich versteckt oder den Kampf vermeidet.
                 %li Beobachter (Observer) dürfen keine taktischen Informationen an die spielenden Teams weitergeben. Taktische Informationen beinhaltet Folgendes:
                 %ol{:type => "a"}
                     %li Das Verraten der Position eines Spielers
-                    %li Das Verraten des Wolle-Trägers auf einer "Capture-the-Wool" map.
+                    %li Das Verraten des Wolle-Trägers auf einer “Capture-the-Wool”-Map.
                 %li Bitte nutze keinen vulgären oder sonstig unpassenden Skin. Du wirst gebannt, bis du einen neuen Skin hast.
                 %li Spawncampe nicht.
                 %ol{:type => "a"}
-                    %li "Spawncampe" nicht, indem du neben oder im Spawn auf neu gespawnte Spieler wartest.
-                    %li Greife keinen Spawn direkt an (z.B. auf einen Spawn zurennen und Spieler dort anzugreifen, sich dort aufzuhalten oder alle Spieler, welche spawnen zu töten).
-                    %li Ziele nicht mit TNT Kanonen auf einen Spawn und lasse kein TNT auf einen Spawn fallen.
-                    %li Do not make the spawn area impassable.
+                    %li „Spawncampe“ nicht, indem du neben oder im Spawn auf neu gespawnte Spieler wartest.
+                    %li Greife keinen Spawn direkt an (z.B. auf einen Spawn zuzurennen und Spieler dort anzugreifen; sich dort aufzuhalten oder alle Spieler, welche spawnen, zu töten).
+                    %li Ziele nicht mit TNT-Kanonen auf einen Spawn und lasse kein TNT auf einen Spawn fallen.
+                    %li Modifiziere das Spawn-Gebiet nicht in einer Weise, sodass dieses unpassierbar ist.
                 %span.label.label-warning Hinweis
-                %small Diese "Spawnkilling" Regeln gelten nicht auf "Team Deathmatch" oder "Blitz" Spielen.
+                %small Diese “Spawnkilling”-Regeln gelten nicht in “Team Deathmatch”- oder “Blitz”-Spielen.
 
     .page-header
-        %h2 F. Modifikationen des Minecraft Clients
+        %h2 F. Modifikationen des Minecraft-Clients
     .row
         .span12
             %ol
-                %li Jegliche Modifikation des Clients, welche dir einen unfairen Vorteil gegenüber anderen gibt, ist illegal.
-                %li Any external tools that modify gameplay to give an unfair advantage over users not using the tool are illegal while playing.
+                %li Jegliche Modifikation des Clients, welche dir einen unfairen Vorteil gegenüber anderen geben, sind illegal.
+                %li Jegliche externe Tools, die das Spiel modifizieren und dir einen unfairen Vorteil gegenüber anderen geben, die diese Tools nicht verwenden, sind illegal.
                 %li Die folgenden Modifikation sind während des Spiels ausdrücklich erlaubt:
                 %ul.unstyled
                     %li
@@ -125,15 +124,15 @@
                         ArmorStatusHUD/StatusEffectHUD
                     %li
                         %i.fa.fa-check
-                        Toggle-crouch, solange es nicht erlaubt zu schleichen, während man schreibt, im Inventar oder im Menü ist
+                        Toggle-Crouch, solange es nicht erlaubt, zu schleichen, während man schreibt, im Inventar oder im Menü ist
                     %li
                         %i.fa.fa-check
-                        Texture Packs, die nicht in die Kategorie "Ausdrücklich verboten" fallen
+                        Texture Packs, die nicht in die Kategorie „Ausdrücklich verboten“ fallen
                     %li
                         %i.fa.fa-check
                         Minimaps, außer den unten beschriebenen
                 %li
-                    %iDie folgenden Modifikationen sind während des Spiels ausdrücklich verboten:
+                    %li Die folgenden Modifikationen sind während des Spiels ausdrücklich verboten:
                 %ul.unstyled
                     %li
                         %i.fa.fa-times
@@ -149,16 +148,16 @@
                         Minimaps, die Entitypositionen, Höhlen und/oder den Untergrund abbilden
                     %li
                         %i.fa.fa-times
-                        Röngten/X-Ray mods
+                        Röngten/X-Ray-Mods
                     %li
                         %i.fa.fa-times
-                        Auto-hitters
+                        Auto-Hitters
                     %li
                         %i.fa.fa-times
                         Aimbots
                     %li
                         %i.fa.fa-times
-                        Fly mods
+                        Fly-Mods
                     %li
                         %i.fa.fa-times
                         Damage/Health Indicator
@@ -168,45 +167,45 @@
                     %li
                         %i.fa.fa-times
                         Better Sprinting
-                %li Falls du irgendeine andere Mod benutzen möchtest, schreibe vorher eine E-mail an support@oc.tc um zu fragen, ob du diese Modifikation benutzen darfst.
+                %li Falls du irgendeine andere Mod benutzen möchtest, schreibe vorher eine E-Mail an support@oc.tc, um zu fragen, ob du diese Modifikation benutzen darfst.
                 %li Beobachter (Observer) sind nicht an diese Regeln gebunden.
                 %span.label.label-warning Hinweis
                 %small Spieler im Kreativ-Modus sind nicht an diese Regeln gebunden.
                 %br
                 %span.label.label-warning Hinweis
-                %small Spieler in der Lobby dürfen keine Fly-Modifikationen benutzten.
+                %small Spieler in der Lobby dürfen keine Fly-Modifikationen benutzen.
 
     .page-header
-        %h2 G. Sabotage des eigenen Teams ("Team Griefing")
+        %h2 G. Sabotage des eigenen Teams (“Team Griefing”)
     .row
         .span12
             %ol
-                %li Die Sabotage des eigenen Teams ("Team griefing") ist verboten, und ist definiert als jegliche Aktion, die deinem Team in irgendeiner Weise schadet.
-                %li Das Folgende zählt als Sabotage des eigenen Teams ("Team Griefing"):
+                %li Die Sabotage des eigenen Teams (“Team griefing”) ist verboten, und ist definiert als jegliche Aktion, die deinem Team in irgendeiner Weise schadet.
+                %li Das Folgende zählt als Sabotage des eigenen Teams (“Team Griefing”):
                 %ol{:type => "a"}
-                    %li Das Plazieren oder Aktivieren von TNT neben Spielkameraden oder wichtigen Punkten auf der Map, z.B. die Ausrüstungskisten.
+                    %li Das Platzieren oder Aktivieren von TNT neben Spielkameraden oder wichtigen Punkten auf der Map, z.B. die Ausrüstungskisten.
                     %li Das Zerstören von Werkbänken des Teams.
-                    %li "Teamkilling" (z.B. durch das Entfernen eines Blocks unter einem Teamkameraden, was ihn zum Fall bringt).
+                    %li “Teamkilling” (z.B. durch das Entfernen eines Blockes unter einem Teamkameraden, was ihn zum Fall bringt).
                     %li Das Nutzen oder Verändern einer Kanone, die man nicht selber gebaut hat.
-                    %li Dem anderen Team helfen oder mit ihnen zusammen, anstatt gegen sie zu arbeiten.
-                %li Das Folgende wird als rücksichtslos und nicht empfehlenswert betrachtet (Du wirst für das Folgende verwarnt, aber nicht direkt bestraft):
+                    %li Dem anderen Team helfen oder mit ihnen zusammen, anstatt gegen sie, zu arbeiten.
+                %li Das Folgende wird als rücksichtslos und nicht empfehlenswert betrachtet (du wirst für das Folgende verwarnt, aber nicht direkt bestraft):
                 %ol{:type => "a"}
                     %li Das Bauen von Säulen aus TNT in der eigenen Basis.
-                    %li Das Mitnehmen von allen oder fast allen Wollblöcken auf einer "Capture the Wool" Map, es sei denn, es ist nur noch ein Wollblock übrig.
-                %li Jeglichte Aktion, die hier nicht gelistet ist, aber trotzdem deinem Team am Gewinnen hindert, wird als Sabotage des eigenen Teams ("Team Griefing") bezeichnet und ebenfalls bestraft.
+                    %li Das Mitnehmen von allen oder fast allen Wollblöcken auf einer “Capture the Wool”-Map, es sei denn, es ist nur noch ein Wollblock übrig.
+                %li Jegliche Aktion, die hier nicht gelistet ist, aber trotzdem deinem Team am Gewinnen hindert, wird als Sabotage des eigenen Teams (“Team Griefing”) bezeichnet und ebenfalls bestraft.
                 %span.label.label-warning Hinweis
                 %small
                     Spieler dürfen sich
                     %b NIEMALS
-                    an Regelbrechern rächen. Nutze /report und lass einen Moderator den Regelbrecher bestrafen.
+                    an Regelbrechern rächen. Nutze “/report” und lasse einen Moderator den Regelbrecher bestrafen.
 
     .page-header
-        %h2 H. Map spezifische Regeln
+        %h2 H. Map-spezifische Regeln
     .row
         .span12
             %ol
-                %li Alle Spieler sind dafür verantwortlich mit den Map-Regeln vertraut zu sein. Sie sind entweder per /map einzusehen, oder stehen auf Schildern am Observer-Spawn.
-                %li Die Regeln von /map haben Vorrang vor denen auf den Schildern.
+                %li Alle Spieler sind dafür verantwortlich, mit den Map-Regeln vertraut zu sein. Sie sind entweder per “/map” einzusehen, oder stehen auf Schildern am Observer-Spawn.
+                %li Die Regeln von “/map” haben Vorrang vor denen auf den Schildern.
 
     .page-header
         %h2 I. Konsequenzen
@@ -215,22 +214,22 @@
             %ol
                 %li Spieler werden bei Regelverstoß entweder verwarnt oder bestraft.
                 %li Die Härte der Strafe ist normalerweise von den vorherigen Regelverstößen des Spielers abhängig.
-                %li Bei besonders schwerwiegenden Regelverstößen, einschließlich das nutzen von "Hacking Clients" oder extremer Sabotage des eigenen Teams ("Team Grief"), wird der Spieler sofort und ohne vorherige Warnung permanent gebannt.
-                %li Spieler mit vielen Warnungen für den gleichen Regelverstoss können temporär gebannt werden.
+                %li Bei besonders schwerwiegenden Regelverstößen, einschließlich das Nutzen von “Hacking Clients” oder extremer Sabotage des eigenen Teams (“Team Grief”), wird der Spieler sofort und ohne vorherige Warnung permanent gebannt.
+                %li Spieler mit vielen Warnungen für den gleichen Regelverstoß können temporär gebannt werden.
                 %li Das Nutzen eines Zweit-Accounts, während der Erst-Account gebannt ist, wird nicht gestattet, und alle Zweit-Accounts werden sofort auch gebannt. Die Zweit-Accounts werden für immer permanent gebannt werden, auch wenn der Bann auf dem Erst-Account abgelaufen ist, und die Länge des Banns auf dem Erst-Account wird verdreifacht.
-                %li Bei extremen Fällen von dieser "Bann-Flucht" werden alle Accounts permanent gebannt.
+                %li Bei extremen Fällen von dieser „Bann-Flucht“ werden alle Accounts permanent gebannt.
                 %li
                     Spieler, die gebannt wurden, werden auch für die Länge des Banns aus den Foren verbannt. Für den Fall, dass dein Bann länger als 7 Tage anhält, kontaktiere bitte
-                    %a{:href => "mailto:support@oc.tc"} support@oc.tc
-                    um die genaue Länge des Forum-Banns rauszufinden.
-                %li Spieler, die gegen die Verhaltensregeln in Mumble verstoßen, werden entweder vom Mumble Server gekickt oder gebannt.
-                %li Spieler, die auf einem der angebotenen Dienste die Regeln brechen (Egal ob Im Spiel, in den Foren, oder in Mumble), können auch von allen anderen Diensten gebannt werden.
+                    %a{:href => "mailto:support@oc.tc"} support@oc.tc,
+                    um die genaue Länge des Forum-Banns herauszufinden.
+                %li Spieler, die gegen die Verhaltensregeln in Mumble verstoßen, werden entweder vom Mumble-Server gekickt oder gebannt.
+                %li Spieler, die auf einem der angebotenen Dienste die Regeln brechen (egal, ob im Spiel, in den Foren, oder in Mumble), können auch von allen anderen Diensten gebannt werden.
                 %li
                     Gegen alle im Spiel ausgehändigten Banns kann unter
                     = succeed '.' do
                         %a{:href => "/appeal"} https://oc.tc/appeal
                         Revision eingelegt werden.
-                    Forum und Mumble Banns werden bitte über
+                    Forum- und Mumble-Banns werden bitte über
                     = succeed '.' do
                         %a{:href => "mailto:support@oc.tc"} support@oc.tc
                         gehandhabt.
@@ -245,6 +244,6 @@
         .span12
             %ol
                 %li Bei Regeländerung werden die Spieler benachrichtigt.
-                %li Die Spieler sind dafür verantwortlich mit den aktualisierten Regeln vertraut zu sein.
+                %li Die Spieler sind dafür verantwortlich, mit den aktualisierten Regeln vertraut zu sein.
                 %li Neue Regeln treten eine Woche nach der Bekanntgabe in Kraft.
-                %li Die "Overcast Network" Administration behält sich das Recht vor, jeden Spieler aus jeglichem Grund und ohne Benachrichtigung von jeglichem "Overcast Network" Dienst zu verbannen.
+                %li Die “Overcast Network”-Administration behält sich das Recht vor, jeden Spieler aus jeglichem Grund und ohne Benachrichtigung von jeglichem “Overcast Network”-Dienst zu verbannen.

--- a/de.haml
+++ b/de.haml
@@ -2,7 +2,7 @@
     .page-header
         %h1
             Regeln
-            %small Zuletzt geändert am 17. März 2015
+            %small Zuletzt geändert am 6. Mai 2015
             = render "select"
     .row
         .span12
@@ -10,7 +10,7 @@
             %span
             Diese Regeln gelten auf
             %b allen von
-            “Overcast Network” angebotenen Diensten.
+            „Overcast Network“ angebotenen Diensten.
 
     .page-header
         %h2
@@ -18,9 +18,9 @@
     .row
         .span12
             %ol
-                %li Bitte bewahre eine angenehme Atmosphäre. Sei respektvoll zu anderen und nutze deinen Verstand. Exzessives Schimpfen, Unfreundlichkeit und Belästigung anderer werden nicht toleriert.
+                %li Bitte bewahre eine angenehme Atmosphäre. Sei respektvoll zu anderen und nutze deinen Verstand. Exzessives Schimpfen, Unfreundlichkeit und Belästigung gegenüber anderen werden nicht toleriert.
                 %li Versuche, korrekte Grammatik und Rechtschreibung einzuhalten (Englisch und andere Sprachen).
-                %li Kein Spam im Chat.
+                %li Spam im Chat ist nicht erlaubt.
                 %li Verlinke keines der folgenden Dinge:
                 %ol{:type => "a"}
                     %li Pornografische Inhalte, „Schock“-Seiten, Viren oder Phishing-Seiten oder nationalsozialistische Inhalte.
@@ -28,7 +28,7 @@
                     %li
                         %a{:href => "https://en.wikipedia.org/wiki/Personally_identifiable_information#Examples"} Personenbezogene Daten von anderen Spielern.
                 %li Regelverstöße, sowie die Unterstützung selbiger, werden nicht toleriert.
-                %li Behaupte nicht, du seist ein Moderator auf dem Overcast Network, wenn du keiner bist.
+                %li Behaupte nicht, du seist ein Moderator des Overcast Networks, wenn du keiner bist.
                 %li Sende Bugs oder dergleichen an support@oc.tc oder erstelle einen Thread in den Foren (http://oc.tc/forums); das Ausnutzen von Bugs wird bestraft, außer du wurdest von einem Moderator angewiesen, den Bug zu demonstrieren.
                 %li Befolge alle Anweisungen eines Overcast Network Moderators. Wenn du glaubst, ein Moderator hat dich falsch angewiesen oder in die Irre geführt, sende eine E-Mail an support@oc.tc.
                 %span.label.label-warning Hinweis
@@ -40,15 +40,15 @@
         .span12
             %ol
                 %li
-                    Erstelle keine Threads um andere Spieler oder Gruppen zu beleidigen oder zu provozieren,
-                    und ermutige andere nicht, solche Posts zu machen.
+                    Erstelle keine Threads (Themen), um andere Spieler oder Gruppen zu beleidigen oder zu provozieren,
+                    und ermutige andere nicht, solche Posts (Beiträge) zu machen.
                 %li Erstelle keine Posts, die inflammatorische Kommentare verspotten oder „prognostizieren“, da diese andere User dazu auffordern, solche Kommentare zu erstellen.
                 %li Antworte nicht mit irrelevanten oder unnützen Nachrichten/Bildern.
-                %li „Bumpe“ keine Threads durch Posts, die nicht konstruktiv zum Thema beitragen.
+                %li „Bumpe“ keine Threads (Themen) durch Posts (Beiträge), die nicht konstruktiv zum Thema beitragen.
                 %li Persönliche Probleme müssen privat besprochen werden. Das Forum ist nicht der richtige Ort für diese Angelegenheiten.
                 %li Kritik an der Arbeit anderer muss höflich und mit Respekt verfasst sein.
                 %li
-                    Erstelle keine Threads, um nur bekannt zu geben, dass du den Server oder das Spiel verlässt.
+                    Erstelle keine Threads, um nur bekannt zu geben, dass du den Server verlassen wirst oder das Spiel (Minecraft) beendigst.
                     Es werden Ausnahmen genehmigt, wenn ein <em>sehr</em> interessanter Grund vorliegt, zum Beispiel, dass du im Sterben liegst oder einmal um die Welt segeln willst.
                 %li
                     Threads über dramatische Ereignisse, die andere Spieler betreffen, müssen überprüfbare Quellenangaben aufweisen.
@@ -57,7 +57,7 @@
                 %li
                     Antworte nicht auf einen Thread oder einen Post, falls du der Meinung bist, dass dieser gegen die Regeln verstößt,
                     %a{:href => "/report"}erstelle stattdessen einen Report. Absichtliches Lügen in einem Report wird bestraft.
-                %li Nutze das HTML in deinem Profil oder in Forenposts nicht aus, sodass es die Navigation erschwert, den Browser zum Laggen bringt oder die vorgegeben Grenzen überschreitet.
+                %li Nutze HTML in deinem Profil oder in Forumposts nicht aus, sodass es die Navigation erschwert, den Browser zum Laggen (= Verlangsamen) bringt oder die vorgegeben Grenzen überschreitet.
                 %small.label.label-warning Hinweis
                 %small Der Inhalt deines Profils kann ohne vorherige Warnung gelöscht werden.
 
@@ -66,9 +66,9 @@
     .row
         .span12
             %ol
-                %li Gib dich in Mumble nicht als jemand anderen aus als du bist.
+                %li Gib dich in Mumble nicht als jemand anderen aus, als du bist.
                 %li Dein Mumble-Nickname sollte dein Minecraft-Name sein, oder eine leicht zu erkennende Variation.
-                %li Spamme keine Sprachnachrichten, d.h. drücke nicht schnell auf den “Mute”-Knopf oder ähnliches.
+                %li Spamme keine Sprachnachrichten, d.h., drücke nicht schnell auf den „Mute“-Knopf oder ähnliches.
 
     .page-header
         %h2 D. Verhalten auf dem Server
@@ -76,11 +76,11 @@
         .span12
             %ol
                 %li Schreibe keine Nachrichten, die Spieler dazu auffordern, das Team oder den Server zu verlassen.
-                %li Fordere niemanden dazu auf, jemand anderen mit “/report” zu melden.
-                %li Bitte beschuldige keine anderen Spieler öffentlich des Hackens. Falls du glaubst, dass ein Spieler hackt oder irgendeine andere Regel bricht, melde sie mit dem “/report”-Befehl.
-                %li Du sollst nicht in irgendeiner Form den Chat im Spiel verwenden, um zu werben. Jedes Benutzerkonto, das alleinig für Webung verwendet wird, wird ohne vorherige Warnung permanent gebannt.
-                %li Du sollst keine IPs von Servern, die nicht zum Overcast Network gehören, in den Chat schreiben. (Du kannst den “/msg”-Befehl benutzen um einem Spieler die IP zu schicken, falls er danach gefragt hat.)
-                %li Dein Benutzername muss angemessen sein, und du könntest dazu aufgefordert werden, einen anderen Account zu nutzen, falls dein Benutzername unangemessen ist. (Dies zählt nicht als Bannumgehung.)
+                %li Fordere niemanden dazu auf, jemand anderen mit „/report“ zu melden.
+                %li Bitte beschuldige keine anderen Spieler öffentlich des Hackens. Falls du glaubst, dass ein Spieler hackt oder irgendeine andere Regel bricht, melde sie mit dem „/report“-Befehl.
+                %li Du sollst nicht in irgendeiner Form den Chat im Spiel verwenden, um zu werben. Jedes Benutzerkonto, das alleinig für Werbung verwendet wird, wird ohne vorherige Warnung permanent gebannt.
+                %li Du sollst keine IP-Adressen von Servern, die nicht zum Overcast Network gehören, in den Chat schreiben. (Du kannst den „/msg“-Befehl verwenden, um einem Spieler die IP-Adresse zu schicken, falls er danach gefragt hat.)
+                %li Dein Benutzername muss angemessen sein, und du könntest dazu aufgefordert werden, einen anderen Account zu nutzen, falls dein Benutzername unangemessen ist. (Dies zählt nicht als eine Bannumgehung.)
                 %span.label.label-warning Hinweis
                 %small Alle Nachrichten und eingegebene Kommandos werden gespeichert.
                 %br
@@ -92,28 +92,28 @@
     .row
         .span12
             %ol
-                %li Spieler dürfen nicht Bugs in Minecraft ausnutzen, um einen Vorteil gegenüber anderen Spielern zu erlangen. Dies beinhaltet Folgendes: Blöcke dort platzieren, wo das Plugin es eigentlich nicht erlaubt, um auf diesem Block zu laufen; eine “X-Ray”-Maschine mit Glowstone oder TNT zu bauen; und um dich unbesiegbar zu machen.
-                %li In “Blitz”- oder “Ghost Squadron”-Spielen ist es verboten, die Partie zu verlängern, indem man sich versteckt oder den Kampf vermeidet.
-                %li Beobachter (Observer) dürfen keine taktischen Informationen an die spielenden Teams weitergeben. Taktische Informationen beinhaltet Folgendes:
+                %li Spieler dürfen nicht Bugs in Minecraft ausnutzen, um einen Vorteil gegenüber anderen Spielern zu erlangen. Dies beinhaltet Folgendes: Blöcke dort platzieren, wo das Plugin es eigentlich nicht erlaubt, um auf diesem Block zu laufen; eine „X-Ray“-Maschine mit Glowstone oder TNT zu bauen; und um dich unbesiegbar zu machen.
+                %li In „Blitz“- oder „Ghost Squadron“-Spielen ist es verboten, die Partie zu verlängern, indem man sich versteckt oder den Kampf vermeidet.
+                %li Beobachter („Observers“) dürfen keine taktischen Informationen an die spielenden Teams weitergeben. Taktische Informationen beinhaltet Folgendes:
                 %ol{:type => "a"}
                     %li Das Verraten der Position eines Spielers
-                    %li Das Verraten des Wolle-Trägers auf einer “Capture-the-Wool”-Map.
+                    %li Das Verraten des Wolle-Trägers auf einer „Capture-the-Wool“-Map.
                 %li Bitte nutze keinen vulgären oder sonstig unpassenden Skin. Du wirst gebannt, bis du einen neuen Skin hast.
                 %li Spawncampe nicht.
                 %ol{:type => "a"}
-                    %li „Spawncampe“ nicht, indem du neben oder im Spawn auf neu gespawnte Spieler wartest.
-                    %li Greife keinen Spawn direkt an (z.B. auf einen Spawn zuzurennen und Spieler dort anzugreifen; sich dort aufzuhalten oder alle Spieler, welche spawnen, zu töten).
+                    %li „Spawncampe“ nicht, indem du neben oder im Spawn (Startpunktgebäude) auf neu gespawnte Spieler wartest.
+                    %li Greife keinen Spawn direkt an (z. B. auf einen Spawn zuzurennen, Spieler dort anzugreifen; sich dort aufzuhalten oder alle Spieler, welche spawnen, zu töten).
                     %li Ziele nicht mit TNT-Kanonen auf einen Spawn und lasse kein TNT auf einen Spawn fallen.
                     %li Modifiziere das Spawn-Gebiet nicht in einer Weise, sodass dieses unpassierbar ist.
                 %span.label.label-warning Hinweis
-                %small Diese “Spawnkilling”-Regeln gelten nicht in “Team Deathmatch”- oder “Blitz”-Spielen.
+                %small Diese „Spawnkilling“-Regeln gelten nicht in „Team Deathmatch“- oder „Blitz“-Spielen.
 
     .page-header
         %h2 F. Modifikationen des Minecraft-Clients
     .row
         .span12
             %ol
-                %li Jegliche Modifikation des Clients, welche dir einen unfairen Vorteil gegenüber anderen geben, sind illegal.
+                %li Jegliche Modifikation des Clients (Programms), welche dir einen unfairen Vorteil gegenüber anderen geben, sind illegal.
                 %li Jegliche externe Tools, die das Spiel modifizieren und dir einen unfairen Vorteil gegenüber anderen geben, die diese Tools nicht verwenden, sind illegal.
                 %li Die folgenden Modifikation sind während des Spiels ausdrücklich erlaubt:
                 %ul.unstyled
@@ -168,45 +168,45 @@
                     %li
                         %i.fa.fa-times
                         Better Sprinting
-                %li Falls du irgendeine andere Mod benutzen möchtest, schreibe vorher eine E-Mail an support@oc.tc, um zu fragen, ob du diese Modifikation benutzen darfst.
-                %li Beobachter (Observer) sind nicht an diese Regeln gebunden.
+                %li Falls du irgendeine andere Modifikation benutzen möchtest, schreibe vorher eine E-Mail an support@oc.tc, um zu fragen, ob du diese Modifikation benutzen darfst.
+                %li Beobachter („Observers“) sind nicht an diese Regeln gebunden.
                 %span.label.label-warning Hinweis
                 %small Spieler im Kreativ-Modus sind nicht an diese Regeln gebunden.
                 %br
                 %span.label.label-warning Hinweis
-                %small Spieler in der Lobby dürfen keine Fly-Modifikationen benutzen.
+                %small Spieler in der Lobby dürfen keine „Fly“-Modifikationen benutzen.
 
     .page-header
-        %h2 G. Sabotage des eigenen Teams (“Team Griefing”)
+        %h2 G. Sabotage des eigenen Teams („Team Griefing“)
     .row
         .span12
             %ol
-                %li Die Sabotage des eigenen Teams (“Team griefing”) ist verboten, und ist definiert als jegliche Aktion, die deinem Team in irgendeiner Weise schadet.
-                %li Das Folgende zählt als Sabotage des eigenen Teams (“Team Griefing”):
+                %li Die Sabotage des eigenen Teams („Team griefing“) ist verboten, und ist definiert als jegliche Aktion, die deinem Team in irgendeiner Weise schadet.
+                %li Das Folgende zählt als Sabotage des eigenen Teams („Team Griefing“):
                 %ol{:type => "a"}
-                    %li Das Platzieren oder Aktivieren von TNT neben Spielkameraden oder wichtigen Punkten auf der Map, z.B. die Ausrüstungskisten.
+                    %li Das Platzieren oder Aktivieren von TNT neben Spielkameraden oder wichtigen Punkten auf der Map, z. B. die Ausrüstungskisten.
                     %li Das Zerstören von Werkbänken des Teams.
-                    %li “Teamkilling” (z.B. durch das Entfernen eines Blockes unter einem Teamkameraden, was ihn zum Fall bringt).
+                    %li „Teamkilling“ (z.B. durch das Entfernen eines Blockes unter einem Teamkameraden, was ihn zum Fall bringt).
                     %li Das Nutzen oder Verändern einer Kanone, die man nicht selber gebaut hat.
                     %li Dem anderen Team helfen oder mit ihnen zusammen, anstatt gegen sie, zu arbeiten.
                 %li Das Folgende wird als rücksichtslos und nicht empfehlenswert betrachtet (du wirst für das Folgende verwarnt, aber nicht direkt bestraft):
                 %ol{:type => "a"}
                     %li Das Bauen von Säulen aus TNT in der eigenen Basis.
-                    %li Das Mitnehmen von allen oder fast allen Wollblöcken auf einer “Capture the Wool”-Map, es sei denn, es ist nur noch ein Wollblock übrig.
-                %li Jegliche Aktion, die hier nicht gelistet ist, aber trotzdem deinem Team am Gewinnen hindert, wird als Sabotage des eigenen Teams (“Team Griefing”) bezeichnet und ebenfalls bestraft.
+                    %li Das Mitnehmen von allen oder fast allen Wollblöcken auf einer „Capture the Wool“-Map, es sei denn, es ist nur noch ein Wollblock übrig.
+                %li Jegliche Aktion, die hier nicht gelistet ist, aber trotzdem deinem Team am Gewinnen hindert, wird als Sabotage des eigenen Teams („Team Griefing“) bezeichnet und ebenfalls bestraft.
                 %span.label.label-warning Hinweis
                 %small
                     Spieler dürfen sich
                     %b NIEMALS
-                    an Regelbrechern rächen. Nutze “/report” und lasse einen Moderator den Regelbrecher bestrafen.
+                    an Regelbrechern rächen. Nutze „/report“ und lasse einen Moderator den Regelbrecher bestrafen.
 
     .page-header
         %h2 H. Map-spezifische Regeln
     .row
         .span12
             %ol
-                %li Alle Spieler sind dafür verantwortlich, mit den Map-Regeln vertraut zu sein. Sie sind entweder per “/map” einzusehen, oder stehen auf Schildern am Observer-Spawn.
-                %li Die Regeln von “/map” haben Vorrang vor denen auf den Schildern.
+                %li Alle Spieler sind dafür verantwortlich, mit den Map-Regeln vertraut zu sein. Sie sind entweder per „/map“ einzusehen, oder stehen auf Schildern am Observer-Spawn.
+                %li Die Regeln von „/map“ haben Vorrang vor denen auf den Schildern.
 
     .page-header
         %h2 I. Konsequenzen
@@ -215,7 +215,7 @@
             %ol
                 %li Spieler werden bei Regelverstoß entweder verwarnt oder bestraft.
                 %li Die Härte der Strafe ist normalerweise von den vorherigen Regelverstößen des Spielers abhängig.
-                %li Bei besonders schwerwiegenden Regelverstößen, einschließlich das Nutzen von “Hacking Clients” oder extremer Sabotage des eigenen Teams (“Team Grief”), wird der Spieler sofort und ohne vorherige Warnung permanent gebannt.
+                %li Bei besonders schwerwiegenden Regelverstößen, einschließlich das Nutzen von „Hacking Clients“ (= mit Hacks modifizierten Programmen) oder extremer Sabotage des eigenen Teams („Team Grief“), wird der Spieler sofort und ohne vorherige Warnung permanent gebannt.
                 %li Spieler mit vielen Warnungen für den gleichen Regelverstoß können temporär gebannt werden.
                 %li Das Nutzen eines Zweit-Accounts, während der Erst-Account gebannt ist, wird nicht gestattet, und alle Zweit-Accounts werden sofort auch gebannt. Die Zweit-Accounts werden für immer permanent gebannt werden, auch wenn der Bann auf dem Erst-Account abgelaufen ist, und die Länge des Banns auf dem Erst-Account wird verdreifacht.
                 %li Bei extremen Fällen von dieser „Bann-Flucht“ werden alle Accounts permanent gebannt.
@@ -247,4 +247,4 @@
                 %li Bei Regeländerung werden die Spieler benachrichtigt.
                 %li Die Spieler sind dafür verantwortlich, mit den aktualisierten Regeln vertraut zu sein.
                 %li Neue Regeln treten eine Woche nach der Bekanntgabe in Kraft.
-                %li Die “Overcast Network”-Administration behält sich das Recht vor, jeden Spieler aus jeglichem Grund und ohne Benachrichtigung von jeglichem “Overcast Network”-Dienst zu verbannen.
+                %li Die „Overcast Network“-Administration behält sich das Recht vor, jeden Spieler aus jeglichem Grund und ohne Benachrichtigung von jeglichem „Overcast Network“-Dienst zu verbannen.

--- a/de.haml
+++ b/de.haml
@@ -2,7 +2,7 @@
     .page-header
         %h1
             Regeln
-            %small Zuletzt geändert am 21. Februar 2015
+            %small Zuletzt geändert am 17. März 2015
             = render "select"
     .row
         .span12

--- a/de.haml
+++ b/de.haml
@@ -78,6 +78,7 @@
                 %li Schreibe keine Nachrichten, die Spieler dazu auffordern, das Team oder den Server zu verlassen.
                 %li Fordere niemanden dazu auf, jemand anderen mit “/report” zu melden.
                 %li Bitte beschuldige keine anderen Spieler öffentlich des Hackens. Falls du glaubst, dass ein Spieler hackt oder irgendeine andere Regel bricht, melde sie mit dem “/report”-Befehl.
+                %li Du sollst nicht in irgendeiner Form den Chat im Spiel verwenden, um zu werben. Jedes Benutzerkonto, das alleinig für Webung verwendet wird, wird ohne vorherige Warnung permanent gebannt.
                 %li Du sollst keine IPs von Servern, die nicht zum Overcast Network gehören, in den Chat schreiben. (Du kannst den “/msg”-Befehl benutzen um einem Spieler die IP zu schicken, falls er danach gefragt hat.)
                 %li Dein Benutzername muss angemessen sein, und du könntest dazu aufgefordert werden, einen anderen Account zu nutzen, falls dein Benutzername unangemessen ist. (Dies zählt nicht als Bannumgehung.)
                 %span.label.label-warning Hinweis


### PR DESCRIPTION
I corrected (I hope) all grammatical mistakes, mostly missing punctuation.
Section B of the German rules (https://oc.tc/rules/de) is not updated yet. However, I used a already submitted translation written by firstvirus92 (https://github.com/firstvirus92/rules/commit/9d9f4b01dc81fbad0260fd626ab34e8e8d759ad6) for section B.

I also edited a bit of the formal design, mostly incorrect quotation marks and word compositions of German and English words or compositions of both words (e.g.: [„/report“-Befehl], actually meaning [“/report” command] instead of [/report Befehl], meaning [/report command]).