### PR TITLE
Added a rule regarding correct usage of /nick.

### DIFF
--- a/en.yml
+++ b/en.yml
@@ -54,6 +54,7 @@ en:
                 - You may not use any form of in game chat to solicit. Any account that is determined to be for the sole use of soliciting will be permanently banned without warning.
                 - You may not link to, or solicit players to join, any server public or private that is not part of the Overcast Network in public chat. (You may use /msg command to inform players that request it).
                 - Your username must be appropriate, and you may be asked to use a different account if your username is found to be inappropriate. (This does not count as ban evasion.)
+                - If you have access to the /nick command, any chosen nickname should be designed to confer anonymity, not attention. You may not use /nick to impersonate others, and you may not use an inappropriate nickname.
                 notes:
                 - All chat messages and commands are logged.
                 - You may link to your Overcast Network related livestream, so long as you don’t spam it.


### PR DESCRIPTION
Based on the rules given in https://oc.tc/forums/topics/5511950a5f35b9c8ef001ef0. I've left out the "greater than 4 letters" part, since I believe /nick no longer allows short names anyway.