### PR TITLE
Mumble/forum bans

### DIFF
--- a/en.haml
+++ b/en.haml
@@ -80,7 +80,7 @@
                 %li Please do not publicly accuse any players of hacking. If you believe a player is hacking or breaking any rules report them using the /report command.
                 %li You may not use any form of in game chat to solicit. Any account that is determined to be for the sole use of soliciting will be permanently banned without warning.
                 %li You may not link to, or solicit players to join, any server public or private that is not part of the Overcast Network in public chat. (You may use the /msg command to inform players that request it).
-                %li Your username must be appropriate, and you may be asked to use a different account if your username is found to be inappropriate. (This does not count as ban evasion).
+                %li Your username must be appropriate, and you may be asked to use a different account if your username is found to be inappropriate. (This does not count as ban evasion.)
                 %span.label.label-warning Note
                 %small All chat messages and commands are logged.
                 %br

--- a/en.haml
+++ b/en.haml
@@ -219,19 +219,13 @@
                 %li Players with many warnings for the same rule may be temporarily banned without notice.
                 %li Ban evasion is not permitted and will result in a permanent ban for all alternate accounts associated with the evading player. The alternate accounts will not be unbanned once the original ban expired, and the original ban may be extended up to thrice the length of the original ban. (e.g. 1 week ban becomes up to a 3 week ban).
                 %li Persistent ban evasion will result in a permanent ban for all accounts.
-                %li
-                    Players violating any forum rules may be banned from posting to the forums. If your ban stays for more than 7 days please contact
-                    %a{:href => "mailto:support@oc.tc"} support@oc.tc
-                    for the exact length of your ban.
-                %li Players violating any mumble rules may be kicked or banned from the mumble server
+                %li Players violating any forum rules may be banned from posting to the forums.
+                %li Players violating any mumble rules may be kicked or banned from the mumble server.
                 %li Players violating the rules on any Overcast Network service, including the game servers, the forums, and mumble, may be banned from any or all of the services.
                 %li
                     In game bans must be appealed by filing an appeal at
                     = succeed '.' do
                         %a{:href => "/appeal"} https://oc.tc/appeal
-                    Forum and mumble bans must be appealed via an email to
-                    = succeed '.' do
-                        %a{:href => "mailto:support@oc.tc"} support@oc.tc
                 %li
                     %b Any player that knowingly gives false info in his or her appeal may be permanently banned.
                 %span.label.label-warning Note

--- a/en.haml
+++ b/en.haml
@@ -79,8 +79,8 @@
                 %li Unless you are explaining the report process, you may not encourage others to report a specific player.
                 %li Please do not publicly accuse any players of hacking. If you believe a player is hacking or breaking any rules report them using the /report command.
                 %li You may not use any form of in game chat to solicit. Any account that is determined to be for the sole use of soliciting will be permanently banned without warning.
-                %li You may not link to, or solicit players to join, any server public or private that is not part of the Overcast Network in public chat. (You may use /msg command to inform players that request it).
-                %li Your username must be appropriate, and you may be asked to use a different account if your username is found to be inappropriate. (This does not count as ban evasion.)
+                %li You may not link to, or solicit players to join, any server public or private that is not part of the Overcast Network in public chat. (You may use the /msg command to inform players that request it).
+                %li Your username must be appropriate, and you may be asked to use a different account if your username is found to be inappropriate. (This does not count as ban evasion).
                 %span.label.label-warning Note
                 %small All chat messages and commands are logged.
                 %br
@@ -180,7 +180,7 @@
     .row
         .span12
             %ol
-                %li Team griefing is prohibited, and is defined as any reckless action that harms your own team, or actions that intentionally harms one's own team.
+                %li Team griefing is prohibited and is defined as any reckless action that harms your own team, or actions that intentionally harms one's own team.
                 %li The following are explicitly team griefing:
                 %ol{:type => "a"}
                     %li Placing and/or setting off TNT near teammates or near key team infrastructure (eg. chests, defences or ore) within one’s own base
@@ -217,7 +217,7 @@
                 %li The severity of the infraction is usually based on the player’s previous infractions.
                 %li In particularly serious or blatant cases of rules violation, including but not limited to using a hacking client on the servers, or consistently team griefing despite moderator intervention, will result in an immediate permanent ban, without warning.
                 %li Players with many warnings for the same rule may be temporarily banned without notice.
-                %li Ban evasion is not permitted, and will result in a permanent ban for all alternate accounts associated with the evading player. The alternate accounts will not be unbanned once the original ban expired, and the original ban may be extended up to thrice the length of the original ban. (e.g. 1 week ban becomes up to a 3 week ban).
+                %li Ban evasion is not permitted and will result in a permanent ban for all alternate accounts associated with the evading player. The alternate accounts will not be unbanned once the original ban expired, and the original ban may be extended up to thrice the length of the original ban. (e.g. 1 week ban becomes up to a 3 week ban).
                 %li Persistent ban evasion will result in a permanent ban for all accounts.
                 %li
                     Players violating any forum rules may be banned from posting to the forums. If your ban stays for more than 7 days please contact


### PR DESCRIPTION
Removed some information about emailing support which is no longer relevant, since mumble and forum bans are now handled through the usual appeal process.

The commits for the previous two PRs I made are included in this. I'm bad at git, sorry.