### PR TITLE
Mumble/forum bans

### DIFF
--- a/en.yml
+++ b/en.yml
@@ -144,11 +144,10 @@ en:
                 - Players with many warnings for the same rule may be temporarily banned without notice.
                 - Ban evasion is not permitted, and will result in a permanent ban for all alternate accounts associated with the evading player. The alternate accounts will not be unbanned once the original ban expired, and the original ban may be extended up to thrice the length of the original ban. (e.g. 1 week ban becomes up to a 3 week ban).
                 - Persistent ban evasion will result in a permanent ban for all accounts.
-                - Players violating any forum rules may be banned from posting to the forums. If your ban stays for more than 7 days please contact support@oc.tc for the exact length of your ban.
+                - Players violating any forum rules may be banned from posting to the forums.
                 - Players violating any mumble rules may be kicked or banned from the mumble server.
                 - Players violating the rules on any Overcast Network service, including the game servers, the forums, and mumble, may be banned from any or all of the services.
-                - In game bans must be appealed by filing an appeal.
-                - Forum and mumble bans must be appealed via an email to support@oc.tc.
+                - All infractions may be appealed by filing an appeal.
                 - '**Any player that knowingly gives false info in his or her appeal may be permanently banned.**'
                 notes:
                 - All infractions are subject to staff discretion.


### PR DESCRIPTION
Removed some information about emailing support which is no longer relevant, since mumble and forum bans are now handled through the usual appeal process.