### PR TITLE
Fix rule F2 beeing duplicate of F1 in Swedish

### DIFF
--- a/sv.haml
+++ b/sv.haml
@@ -96,7 +96,7 @@
         .col-md-12
             %ol
                 %li Alla klientmodifikationer som ger ett orättvist övertag över användare utan samma modifikationer är förbjudna medan man spelar.
-                %li Alla klientmodifikationer som ger ett orättvist övertag över användare utan samma modifikationer är förbjudna medan man spelar.
+                %li Alla externa verktyg som förändrar spelet för att ge ett orättvist övertag över andra spelare som inte använder verktyget är olagligt medans man spelar.
                 %li Följande modifikationer är uttryckligen tillåtna medans man spelar:
                 %ul.unstyled
                     %li


### PR DESCRIPTION
The F1 and F2 rule on [rules/sv](https://oc.tc/rules/sv) was a duplicate for some reason, possibly because of some old error on Crowdin, but this PR fixes it.

# Original

>Any client modifications that give an unfair advantage over vanilla Minecraft users are illegal while playing.
>Any external tools that modify gameplay to give an unfair advantage over users not using the tool are illegal while playing.

# Before

>Alla klientmodifikationer som ger ett orättvist övertag över användare utan samma modifikationer är förbjudna medan man spelar.
>Alla klientmodifikationer som ger ett orättvist övertag över användare utan samma modifikationer är förbjudna medan man spelar.

# After

>Alla klientmodifikationer som ger ett orättvist övertag över användare utan samma modifikationer är förbjudna medan man spelar.
>Alla externa verktyg som förändrar spelet för att ge ett orättvist övertag över andra spelare som inte använder verktyget är olagligt medans man spelar.

---

This also affects [crowdin/ocn-website/en-sv#1633](https://crowdin.com/translate/ocn-website/73/en-sv#1633) which I just fixed with the same string, and it can be modified if needed.